### PR TITLE
#22 Add RemoveOnStop to minecraft.socket

### DIFF
--- a/templates/minecraft.socket.j2
+++ b/templates/minecraft.socket.j2
@@ -6,6 +6,7 @@ ListenFIFO={{ minecraft_console_fifo }}
 SocketUser={{ minecraft_user }}
 SocketGroup={{ minecraft_group }}
 SocketMode={{ minecraft_console_fifo_mode }}
+RemoveOnStop=true
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
Removes /run/minecraft/console on minecraft.socket stop or in mid restart, so the socket is able to start.