### PR TITLE
Fix broken papermc support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,6 @@ minecraft_console_fifo_mode: '0666'
 minecraft_server_properties: {}
 minecraft_eula_accept: false
 minecraft_spigot_url: https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-minecraft_paper_url: https://papermc.io/api/v2/projects/paper/versions/1.18.2/builds/290/downloads/paper-1.18.2-290.jar
 minecraft_server_java_ops:
 minecraft_java: /usr/bin/java
 #minecraft_java_external_managed: true

--- a/tasks/download/paper.yml
+++ b/tasks/download/paper.yml
@@ -1,9 +1,35 @@
 ---
-- name: download PaperMC server
+
+- name: Get PaperMC build info
+  uri:
+    url: "https://api.papermc.io/v2/projects/paper/versions/{{ minecraft_version }}/builds"
+    method: GET
+  register: minecraft_paper_build_info
+
+- name: Set latest paper build and checksum
+  set_fact:
+    minecraft_paper_latest_build: "{{ minecraft_paper_build_info.json.builds[-1].build }}"
+    minecraft_paper_checksum: "{{ minecraft_paper_build_info.json.builds[-1].downloads.application.sha256 }}"
+  when: minecraft_paper_build is not defined or minecraft_paper_build|string|length==0
+
+- name: Build download URI
+  set_fact:
+    minecraft_paper_url: "https://api.papermc.io/v2/projects/paper/versions/{{ minecraft_version }}/builds/{{ minecraft_paper_build | default(minecraft_paper_latest_build) }}/downloads/paper-{{ minecraft_version }}-{{ minecraft_paper_build | default(minecraft_paper_latest_build) }}.jar"
+  when: minecraft_paper_url is not defined or minecraft_paper_url|length==0
+
+# - name: Get checksum of custom build
+#   set_fact:
+#     minecraft_paper_checksum: "{{ item.downloads.application.sha256 }}"
+#   loop: "{{ minecraft_paper_build_info.json.builds }}"
+#   loop_control:
+#     label: false
+#   when: minecraft_paper_build is defined and item.build == minecraft_paper_build | int
+
+- name: Download PaperMC server
   get_url:
     url: "{{ minecraft_paper_url }}"
-    dest: "{{ deploy_helper.new_release_path }}/minecraft_server.jar"
+    dest: "{{ deploy_helper.new_release_path }}/paper-{{ minecraft_version }}.jar"
     owner: "{{ minecraft_user }}"
     group: "{{ minecraft_group }}"
-    # checksum: "{{ minecraft_server_download_checksum }}"
+    checksum: "sha256:{{ minecraft_paper_checksum }}"
     mode: '0755'

--- a/tasks/download/paper.yml
+++ b/tasks/download/paper.yml
@@ -17,14 +17,6 @@
     minecraft_paper_url: "https://api.papermc.io/v2/projects/paper/versions/{{ minecraft_version }}/builds/{{ minecraft_paper_build | default(minecraft_paper_latest_build) }}/downloads/paper-{{ minecraft_version }}-{{ minecraft_paper_build | default(minecraft_paper_latest_build) }}.jar"
   when: minecraft_paper_url is not defined or minecraft_paper_url|length==0
 
-# - name: Get checksum of custom build
-#   set_fact:
-#     minecraft_paper_checksum: "{{ item.downloads.application.sha256 }}"
-#   loop: "{{ minecraft_paper_build_info.json.builds }}"
-#   loop_control:
-#     label: false
-#   when: minecraft_paper_build is defined and item.build == minecraft_paper_build | int
-
 - name: Download PaperMC server
   get_url:
     url: "{{ minecraft_paper_url }}"

--- a/tasks/install/paper.yml
+++ b/tasks/install/paper.yml
@@ -1,8 +1,8 @@
 ---
-- name: Add symlinks from the new release to the shared folder
+- name: Add symlinks from the new paper release to the shared folder
   file:
     dest: "{{ deploy_helper.shared_path }}/paper.jar"
-    src: "{{ deploy_helper.current_path }}/paper-{{ minecraft_version_int }}.jar"
+    src: "{{ deploy_helper.current_path }}/paper-{{ minecraft_version }}.jar"
     owner: "{{ minecraft_user }}"
     group: "{{ minecraft_group }}"
     state: link

--- a/tasks/setup/main.yml
+++ b/tasks/setup/main.yml
@@ -31,3 +31,8 @@
   set_fact:
     minecraft_jar: spigot.jar
   when: minecraft_server == 'spigot'
+
+- name: set executable name (Paper)
+  set_fact:
+    minecraft_jar: paper.jar
+  when: minecraft_server == 'paper'


### PR DESCRIPTION
Hi, first of all big thanks for this role.
I freshened up the papermc download and install a bit, as paper works way better than spigot for me. 
The download uri is now automatically build form the given `minecraft_version` number which can still be overwritten with `minecraft_paper_url`. 

I tried to support custom builds (with checksum) too instead of just the latest of the version but I cloud not get it to work without producing a very verbose output. (branch: sleepy-nols/ansible-minecraft/tree/paper_support_costom_builds)

Please suggest changes if something doesnt seem right.  